### PR TITLE
Reusing the ansible_ssh_user.

### DIFF
--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -48,7 +48,7 @@ infrastructure_virtual_machines:
     shape: Standard_B4ms
 
 # Compute
-infrastructure_admin_username: azureuser
+infrastructure_admin_username: "{{ ansible_ssh_user }}"
 infrastructure_password_enabled: false
 
 infrastructure_image_plan:
@@ -59,7 +59,7 @@ infrastructure_image_plan:
 
 infrastructure_keypair_name: id_rsa
 infrastructure_ssh_public_keys:
-  - path: "/home/azureuser/.ssh/authorized_keys"
+  - path: "/home/{{ ansible_ssh_user }}/.ssh/authorized_keys"
     key_data: "{{ lookup('file', lookup('env', 'HOME') + '/.ssh/' + infrastructure_keypair_name + '.pub') }}"
 
 infrastructure_managed_disk_type: Premium_LRS

--- a/roles/infrastructure/tasks/main.yml
+++ b/roles/infrastructure/tasks/main.yml
@@ -45,16 +45,16 @@
       ansible.builtin.copy:
         remote_src: false
         src: "{{ lookup('env', 'HOME') + '/.ssh/' + infrastructure_keypair_name }}"
-        dest: /home/azureuser/.ssh/{{ infrastructure_keypair_name }}
-        owner: azureuser
-        group: azureuser
+        dest: /home/{{ ansible_ssh_user }}/.ssh/{{ infrastructure_keypair_name }}
+        owner: "{{ ansible_ssh_user }}"
+        group: "{{ ansible_ssh_user }}"
         mode: '0600'
         force: true
 
     - name: Copy ssh config to make calling the AAP installer from this role possible
       ansible.builtin.template:
         src: config.j2
-        dest: /home/azureuser/.ssh/config
+        dest: /home/{{ ansible_ssh_user }}/.ssh/config
         mode: '0644'
 
 - name: Create Execution Node VMs

--- a/roles/infrastructure/templates/config.j2
+++ b/roles/infrastructure/templates/config.j2
@@ -1,4 +1,4 @@
 Host {{ groups.controller_private | join(' ') }} {{ groups.execution_private | default('') | join(' ') }} {{ groups.hub_private | default('') | join(' ') }} {{ groups.eda_private | default('') | join(' ') }}
-    User azureuser
-    IdentityFile /home/azureuser/.ssh/{{ infrastructure_keypair_name }}
+    User {{ ansible_ssh_user }}
+    IdentityFile /home/{{ ansible_ssh_user }}/.ssh/{{ infrastructure_keypair_name }}
     StrictHostKeyChecking no


### PR DESCRIPTION
We have `ansible_ssh_user` in group_vars/all.yml, so using that instead of the hardcoded `azureuser`.