### PR TITLE
Fix repo URL in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,10 +43,10 @@ dependencies:
 
 
 # The URL of the originating SCM repository
-repository: https://github.com/ansible-content-lab/azure_deployment
+repository: https://github.com/ansible-content-lab/azure_ansible_deployment
 
 # The URL to the collection issue tracker
-issues: https://github.com/ansible-content-lab/azure_deployment/issues
+issues: https://github.com/ansible-content-lab/azure_ansible_deployment/issues
 
 # A list of file glob-like patterns used to filter any files or directories that should not be included in the build
 # artifact. A pattern is matched from the relative path of the file or directory of the collection directory. This


### PR DESCRIPTION
Do we also need to change the Ansible Collection from:
lab.azure_deployment  
to:
lab.azure_ansible_deployment 
?   
I assume not since ansible is implied.