### PR TITLE
Remove duplicate deprecated parameter public_ip_name

### DIFF
--- a/roles/infrastructure/tasks/vms/create.yml
+++ b/roles/infrastructure/tasks/vms/create.yml
@@ -26,7 +26,7 @@
     name: "nic-{{ deployment_id }}-{{ app_tag }}-{{ infrastructure_vm_deployment_id }}"
     virtual_network: "{{ infrastructure_network.state.id }}"
     subnet: "{{ subnet }}"
-    public_ip_name: "{{ infrastructure_pip.state.name }}"
+    #public_ip_name: "{{ infrastructure_pip.state.name }}"
     security_group: "{{ infrastructure_nsg.state.name }}"
     location: "{{ infrastructure_region }}"
     ip_configurations:

--- a/roles/infrastructure/tasks/vms/create.yml
+++ b/roles/infrastructure/tasks/vms/create.yml
@@ -26,7 +26,6 @@
     name: "nic-{{ deployment_id }}-{{ app_tag }}-{{ infrastructure_vm_deployment_id }}"
     virtual_network: "{{ infrastructure_network.state.id }}"
     subnet: "{{ subnet }}"
-    #public_ip_name: "{{ infrastructure_pip.state.name }}"
     security_group: "{{ infrastructure_nsg.state.name }}"
     location: "{{ infrastructure_region }}"
     ip_configurations:


### PR DESCRIPTION
Seems to be a deprecated parameter for azure.azcollection.azure_rm_networkinterface -> public_ip_name >

Gave error when running playbook > https://github.com/r3dact3d/Ansible-Repo-Template/actions/runs/9358222709/job/25759593045

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (azure.azcollection.azure_rm_networkinterface) module: public_ip_name. Supported parameters include: ad_user, adfs_authority_url, api_profile, append_tags, auth_source, cert_validation_mode, client_id, cloud_environment, create_with_security_group, disable_instance_discovery, dns_servers, enable_accelerated_networking, enable_ip_forwarding, ip_configurations, location, log_mode, log_path, name, open_ports, os_type, password, profile, resource_group, secret, security_group, state, subnet_name, subscription_id, tags, tenant, thumbprint, virtual_network, x509_certificate_path (ip_forwarding, security_group_name, subnet, virtual_network_name)."